### PR TITLE
Allows cross compile linux and macos target for both test and example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *std.Build) void {
     const lib = b.addStaticLibrary(.{ .name = "lmdb-zig", .target = target, .optimize = optimize });
     const dep_lmdb_c = b.dependency("lmdb_c", .{ .target = target, .optimize = optimize });
     lib.addCSourceFiles(.{ .root = dep_lmdb_c.path("libraries/liblmdb"), .files = &.{ "mdb.c", "midl.c" }, .flags = &.{"-fno-sanitize=undefined"} });
+    lib.installHeadersDirectory(dep_lmdb_c.path("libraries/liblmdb"), "", .{ .include_extensions = &.{"lmdb.h"} });
     lib.linkLibC();
     b.installArtifact(lib);
 
@@ -16,16 +17,15 @@ pub fn build(b: *std.Build) void {
     mod.addIncludePath(dep_lmdb_c.path(""));
 
     const tests = b.addTest(.{ .name = "test", .root_source_file = mod.root_source_file.?, .target = target, .optimize = optimize });
-    tests.addIncludePath(b.path("lmdb/libraries/liblmdb"));
     tests.linkLibrary(lib);
     b.installArtifact(tests);
     const test_step = b.step("test", "Run libary tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
 
-    const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
-    exe.root_module.addImport("lmdb-zig", mod);
-    exe.linkLibrary(lib);
-    b.installArtifact(exe);
-    const run_step = b.step("example", "Run example");
-    run_step.dependOn(&b.addRunArtifact(exe).step);
+    // const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
+    // exe.root_module.addImport("lmdb-zig", mod);
+    // exe.linkLibrary(lib);
+    // b.installArtifact(exe);
+    // const run_step = b.step("example", "Run example");
+    // run_step.dependOn(&b.addRunArtifact(exe).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -8,13 +8,16 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addStaticLibrary(.{ .name = "lmdb-zig", .target = target, .optimize = optimize });
     const dep_lmdb_c = b.dependency("lmdb_c", .{ .target = target, .optimize = optimize });
-    lib.addCSourceFiles(.{ .root = dep_lmdb_c.path("libraries/liblmdb"), .files = &.{ "mdb.c", "midl.c" }, .flags = &.{"-fno-sanitize=undefined"} });
-    lib.installHeadersDirectory(dep_lmdb_c.path("libraries/liblmdb"), "", .{ .include_extensions = &.{"lmdb.h"} });
+    const lmdb_path = dep_lmdb_c.path("libraries/liblmdb");
+    lib.addCSourceFiles(.{ .root = lmdb_path, .files = &.{ "mdb.c", "midl.c" }, .flags = &.{"-fno-sanitize=undefined"} });
+    lib.installHeadersDirectory(lmdb_path, "", .{ .include_extensions = &.{"lmdb.h"} });
+    lib.addIncludePath(lmdb_path);
     lib.linkLibC();
     b.installArtifact(lib);
 
     const mod = b.addModule("lmdb-zig-mod", .{ .root_source_file = b.path("lmdb.zig") });
     mod.addIncludePath(dep_lmdb_c.path(""));
+    mod.addIncludePath(lmdb_path);
 
     const tests = b.addTest(.{ .name = "test", .root_source_file = mod.root_source_file.?, .target = target, .optimize = optimize });
     tests.linkLibrary(lib);
@@ -22,10 +25,10 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run libary tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
 
-    // const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
-    // exe.root_module.addImport("lmdb-zig", mod);
-    // exe.linkLibrary(lib);
-    // b.installArtifact(exe);
-    // const run_step = b.step("example", "Run example");
-    // run_step.dependOn(&b.addRunArtifact(exe).step);
+    const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
+    exe.root_module.addImport("lmdb-zig", mod);
+    exe.linkLibrary(lib);
+    b.installArtifact(exe);
+    const run_step = b.step("example", "Run example");
+    run_step.dependOn(&b.addRunArtifact(exe).step);
 }


### PR DESCRIPTION
The include path was modified to match the original library.

Now it's possible to run

zig build -Dtarget=x86_64-macos

zig build -Dtarget=x86_64-linux