### PR TITLE
Allows to cross compile to windows OS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,7 @@ pub fn build(b: *std.Build) void {
     const lib = b.addStaticLibrary(.{ .name = "lmdb-zig", .target = target, .optimize = optimize });
     const dep_lmdb_c = b.dependency("lmdb_c", .{ .target = target, .optimize = optimize });
     lib.addCSourceFiles(.{ .root = dep_lmdb_c.path("libraries/liblmdb"), .files = &.{ "mdb.c", "midl.c" }, .flags = &.{"-fno-sanitize=undefined"} });
+    lib.installHeadersDirectory(dep_lmdb_c.path("libraries/liblmdb"), "", .{ .include_extensions = &.{"lmdb.h"} });
     lib.linkLibC();
     b.installArtifact(lib);
 
@@ -16,16 +17,15 @@ pub fn build(b: *std.Build) void {
     mod.addIncludePath(dep_lmdb_c.path(""));
 
     const tests = b.addTest(.{ .name = "test", .root_source_file = mod.root_source_file.?, .target = target, .optimize = optimize });
-    tests.addIncludePath(b.path("lmdb/libraries/liblmdb"));
     tests.linkLibrary(lib);
     b.installArtifact(tests);
     const test_step = b.step("test", "Run libary tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
 
-    const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
-    exe.root_module.addImport("lmdb-zig", mod);
-    exe.linkLibrary(lib);
-    b.installArtifact(exe);
-    const run_step = b.step("example", "Run example");
-    run_step.dependOn(&b.addRunArtifact(exe).step);
+    // const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
+    // exe.root_module.addImport("lmdb-zig", mod);
+    // exe.linkLibrary(lib);
+    // b.installArtifact(exe);
+    // const run_step = b.step("example", "Run example");
+    // run_step.dependOn(&b.addRunArtifact(exe).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -8,13 +8,16 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addStaticLibrary(.{ .name = "lmdb-zig", .target = target, .optimize = optimize });
     const dep_lmdb_c = b.dependency("lmdb_c", .{ .target = target, .optimize = optimize });
-    lib.addCSourceFiles(.{ .root = dep_lmdb_c.path("libraries/liblmdb"), .files = &.{ "mdb.c", "midl.c" }, .flags = &.{"-fno-sanitize=undefined"} });
-    lib.installHeadersDirectory(dep_lmdb_c.path("libraries/liblmdb"), "", .{ .include_extensions = &.{"lmdb.h"} });
+    const lmdb_path = dep_lmdb_c.path("libraries/liblmdb");
+    lib.addCSourceFiles(.{ .root = lmdb_path, .files = &.{ "mdb.c", "midl.c" }, .flags = &.{"-fno-sanitize=undefined"} });
+    lib.installHeadersDirectory(lmdb_path, "", .{ .include_extensions = &.{"lmdb.h"} });
+    lib.addIncludePath(lmdb_path);
     lib.linkLibC();
     b.installArtifact(lib);
 
     const mod = b.addModule("lmdb-zig-mod", .{ .root_source_file = b.path("lmdb.zig") });
     mod.addIncludePath(dep_lmdb_c.path(""));
+    mod.addIncludePath(lmdb_path);
 
     const tests = b.addTest(.{ .name = "test", .root_source_file = mod.root_source_file.?, .target = target, .optimize = optimize });
     tests.linkLibrary(lib);
@@ -22,10 +25,10 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run libary tests");
     test_step.dependOn(&b.addRunArtifact(tests).step);
 
-    // const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
-    // exe.root_module.addImport("lmdb-zig", mod);
-    // exe.linkLibrary(lib);
-    // b.installArtifact(exe);
-    // const run_step = b.step("example", "Run example");
-    // run_step.dependOn(&b.addRunArtifact(exe).step);
+    const exe = b.addExecutable(.{ .name = "example", .root_source_file = b.path("example.zig"), .target = target, .optimize = optimize });
+    exe.root_module.addImport("lmdb-zig", mod);
+    exe.linkLibrary(lib);
+    b.installArtifact(exe);
+    const run_step = b.step("example", "Run example");
+    run_step.dependOn(&b.addRunArtifact(exe).step);
 }

--- a/lmdb.zig
+++ b/lmdb.zig
@@ -1,4 +1,5 @@
 pub const std = @import("std");
+pub const builtin = @import("builtin");
 pub const assert = std.debug.assert;
 pub const c = @cImport(@cInclude("lmdb.h"));
 
@@ -692,8 +693,11 @@ test "Env: .init() .deinit() .stats() .info() and flags" {
     try test_eql((try env.info()).map_size, 8 * 1024 * 1024);
 
     // The file descriptor should be >= 0.
-
-    try test_eql_true((try env.to_fd()) >= 0);
+    if ( builtin.os.tag != .windows) {
+        // revisit https://github.com/ziglang/zig/issues/13586
+        // try testing with wine a vm or an actual windows OS
+        try test_eql_true((try env.to_fd()) >= 0);
+    }
 
     try test_eql((try env.purge()), 0);
 }


### PR DESCRIPTION
A part of a test is excluded given a problem with opaque struct not being handled.